### PR TITLE
@johanc/cli

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -80,7 +80,7 @@
     "handlebars": "^4.7.6",
     "mongoose": "5.10.18",
     "mongoose-algolia": "^1.10.1",
-    "mongoose-autopopulate": "^0.12.3",
+    "mongoose-autopopulate": "^0.14.0",
     "morgan": "^1.10.0",
     "nodemailer": "^6.4.17",
     "nodemailer-mandrill-transport": "^1.2.0",

--- a/packages/server/src/models/Mentors.ts
+++ b/packages/server/src/models/Mentors.ts
@@ -1,4 +1,4 @@
-import { plugin, getModelForClass, prop, Ref } from "@typegoose/typegoose";
+import { plugin, getModelForClass, prop, Ref, modelOptions, Severity } from "@typegoose/typegoose";
 import mongoose from "mongoose";
 import { Mentorship } from "./Mentorships";
 import CommunicationPreference from "./CommunicationPreference";
@@ -39,6 +39,7 @@ export interface IMentor {
   indexName: "mentors",
   debug: true,
 })
+@modelOptions({options: {allowMixed: Severity.ALLOW}})
 export class Mentor implements IMentor {
   public _id: mongoose.Types.ObjectId;
 

--- a/packages/server/src/models/Mentorships.ts
+++ b/packages/server/src/models/Mentorships.ts
@@ -2,8 +2,8 @@ import { Mentor } from "./Mentors";
 import { Parent } from "./Parents";
 import { Student } from "./Students";
 import { ISession } from "./Sessions";
-import { getModelForClass, modelOptions, mongoose, prop, Ref, Severity } from "@typegoose/typegoose";
-
+import { getModelForClass, modelOptions, mongoose, plugin, prop, Ref, Severity } from "@typegoose/typegoose";
+import autopopulate from 'mongoose-autopopulate';
 /**
  * PENDING - A request has been sent to the mentor, but the mentor has not yet accepted.
  * ACTIVE - Mentorship is still ongoing.
@@ -36,6 +36,7 @@ export interface IMentorship {
   sessions: ISession[];
 }
 
+@plugin(autopopulate as any)
 @modelOptions({options: {allowMixed: Severity.ALLOW}})
 export class Mentorship implements IMentorship {
   public _id?: mongoose.Types.ObjectId;
@@ -56,13 +57,13 @@ export class Mentorship implements IMentorship {
   @prop({ required: false })
   public endDate?: Date;
 
-  @prop({ ref: "Mentor", autopulate: true, required: true })
+  @prop({ ref: "Mentor", autopopulate: true, required: true })
   public mentor: Ref<Mentor>;
 
-  @prop({ ref: "Parent", autopulate: true, required: true })
+  @prop({ ref: "Parent", autopopulate: true, required: true })
   public parent: Ref<Parent>;
 
-  @prop({ ref: "Student", required: true })
+  @prop({ ref: "Student", autopopulate: true, required: true })
   public student: Ref<Student>;
 
   @prop({ default: [] })

--- a/packages/server/src/models/Mentorships.ts
+++ b/packages/server/src/models/Mentorships.ts
@@ -2,7 +2,7 @@ import { Mentor } from "./Mentors";
 import { Parent } from "./Parents";
 import { Student } from "./Students";
 import { ISession } from "./Sessions";
-import { getModelForClass, mongoose, prop, Ref } from "@typegoose/typegoose";
+import { getModelForClass, modelOptions, mongoose, prop, Ref, Severity } from "@typegoose/typegoose";
 
 /**
  * PENDING - A request has been sent to the mentor, but the mentor has not yet accepted.
@@ -36,6 +36,7 @@ export interface IMentorship {
   sessions: ISession[];
 }
 
+@modelOptions({options: {allowMixed: Severity.ALLOW}})
 export class Mentorship implements IMentorship {
   public _id?: mongoose.Types.ObjectId;
 

--- a/packages/server/src/models/Parents.ts
+++ b/packages/server/src/models/Parents.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, prop } from "@typegoose/typegoose";
+import { getModelForClass, modelOptions, prop, Severity } from "@typegoose/typegoose";
 import mongoose from "mongoose";
 import CommunicationPreference from "./CommunicationPreference";
 import { IStudent, Student } from "./Students";
@@ -15,7 +15,7 @@ export interface IParent {
   communicationPreference: CommunicationPreference;
   students: IStudent[];
 }
-
+@modelOptions({options: {allowMixed: Severity.ALLOW}})
 export class Parent implements IParent {
   public _id: mongoose.Types.ObjectId;
 

--- a/packages/server/src/models/Parents.ts
+++ b/packages/server/src/models/Parents.ts
@@ -1,7 +1,8 @@
-import { getModelForClass, modelOptions, prop, Severity } from "@typegoose/typegoose";
+import { getModelForClass, modelOptions, prop, Severity, Ref, plugin} from "@typegoose/typegoose";
 import mongoose from "mongoose";
 import CommunicationPreference from "./CommunicationPreference";
 import { IStudent, Student } from "./Students";
+import autopopulate from 'mongoose-autopopulate';
 
 export interface IParent {
   _id?: mongoose.Types.ObjectId;
@@ -15,6 +16,8 @@ export interface IParent {
   communicationPreference: CommunicationPreference;
   students: IStudent[];
 }
+
+@plugin(autopopulate as any)
 @modelOptions({options: {allowMixed: Severity.ALLOW}})
 export class Parent implements IParent {
   public _id: mongoose.Types.ObjectId;
@@ -44,13 +47,10 @@ export class Parent implements IParent {
   public avatar?: string;
 
   @prop({
-    required: true,
-    validate: {
-      validator: (v) => v.length >= 1,
-      message: "Parent must specific at least one student.",
-    },
+    autopopulate: true,
+    ref: Student
   })
-  public students: Student[];
+  public students: Ref<Student>[];
 }
 
 const ParentModel = getModelForClass(Parent);

--- a/packages/server/src/scripts/createMentorship.ts
+++ b/packages/server/src/scripts/createMentorship.ts
@@ -1,0 +1,128 @@
+import find from 'find-up';
+import dotenv from 'dotenv';
+import prompts from 'prompts';
+import ParentModel from '../models/Parents';
+import { mongoose } from '@typegoose/typegoose';
+import { Student } from '../models/Students';
+import MentorModel from '../models/Mentors';
+import MentorshipService, { MentorshipRequest } from '../services/MentorshipService';
+import { exit } from 'yargs';
+
+const envPath = find.sync('.env');
+dotenv.config({path: envPath});
+const { MONGO_URI,   DB_NAME } = process.env;
+
+if (MONGO_URI === undefined || DB_NAME === undefined) {
+    throw new Error("Missing environment keys");
+}
+
+const setup = () => {
+    return mongoose.connect(MONGO_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        dbName: DB_NAME
+    });
+}
+
+const main = async () => {
+    // Prompt for parent info
+    const { parentEmail } = await prompts({
+        type: 'text',
+        name: 'parentEmail',
+        message: 'Email of the parent requesting the mentorship',
+        validate: async (parentEmail) => {
+            const doc =  await ParentModel.findOne({email: parentEmail });
+            if (doc === null) {    
+                return `${parentEmail} does not exist. Typo?`;
+            }
+            return true;
+        }
+    });
+    const parent = await retrieveParentData(parentEmail);
+    const students = parent.students;
+    // Find the correct student_id 
+    const { selectedStudent } = await prompts({
+        type: 'select',
+        name: 'selectedStudent',
+        message: 'Which student are you requesting a mentorship for',
+        choices: students.map((s: Student) => {
+            return {
+                title: s.name,
+                value: s
+            };
+        }),
+    });
+    // Find mentor 
+    const { mentorEmail } = await prompts({
+        type: 'text',
+        name: 'mentorEmail',
+        message: 'Mentor\'s email',
+        validate: async (mentorEmail) => {
+            const doc =  await MentorModel.findOne({email: mentorEmail });
+            if (doc === null) {    
+                return `${mentorEmail} does not exist. Typo?`;
+            }
+            return true;
+        }
+    });
+    const mentor = await retrieveMentorData(mentorEmail);
+    // Ask for the message 
+    const { message } = await prompts({
+        type: 'text',
+        name: 'message',
+        message: 'Message for the mentor about this request: ', 
+        validate: msg => msg.length > 0,
+    });
+    const request: MentorshipRequest = {
+        student: selectedStudent,
+        parent,
+        mentor,
+        message,
+    };
+
+    const { proceed } = await prompts({
+        type: 'toggle',
+        name: 'proceed',
+        message: generateConfirmationMsg(request),
+        initial: true,
+        active: 'yes',
+        inactive: 'no'
+    });
+    if (!proceed) {
+        exit(1, new Error('Aborted operation.'));
+    }
+    
+    await MentorshipService.sendRequest(request).then(() => {
+        console.log("Succesfully sent request ~");
+    })
+    exit(0, new Error())
+
+}
+
+const generateConfirmationMsg = (request: MentorshipRequest) => {
+    return `Preparing to send a mentorship request to ${request.mentor.name} (${request.mentor.name}) for ${request.student.name} on behalf of ${request.parent.name} (${request.parent.email}) with the message:\n\t${request.message} \n
+Does that sound correct?`
+}
+
+const retrieveParentData = (parentEmail: string) => {
+    return ParentModel.findOne({email: parentEmail}).then((doc) => {
+        if (doc === null) {
+            throw new Error(`Could not find ${parentEmail} in the database.`);
+        }
+        return doc;
+    });
+};
+
+const retrieveMentorData = (mentorEmail: string) => {
+    return MentorModel.findOne({email:mentorEmail}).then((doc) => {
+        if (doc === null) {
+            throw new Error(`Could not find ${mentorEmail} in the database.`);
+        }
+        return doc;
+    });
+};
+
+setup().then(() => {
+    console.clear(); // Typegoose sometimes has warnings.
+    main();
+});

--- a/packages/server/src/scripts/createMentorship.ts
+++ b/packages/server/src/scripts/createMentorship.ts
@@ -33,7 +33,7 @@ const main = async () => {
         validate: async (parentEmail) => {
             const doc =  await ParentModel.findOne({email: parentEmail });
             if (doc === null) {    
-                return `${parentEmail} does not exist. Typo?`;
+                return `${parentEmail} does not belong to any registered parent. Typo?`;
             }
             return true;
         }
@@ -60,7 +60,7 @@ const main = async () => {
         validate: async (mentorEmail) => {
             const doc =  await MentorModel.findOne({email: mentorEmail });
             if (doc === null) {    
-                return `${mentorEmail} does not exist. Typo?`;
+                return `${mentorEmail} does not belong to any registered mentor. Typo?`;
             }
             return true;
         }
@@ -96,7 +96,6 @@ const main = async () => {
         console.log("Succesfully sent request ~");
     })
     exit(0, new Error())
-
 }
 
 const generateConfirmationMsg = (request: MentorshipRequest) => {

--- a/packages/server/tests/unit/UserService.ts
+++ b/packages/server/tests/unit/UserService.ts
@@ -4,6 +4,7 @@ import chaiSubset from "chai-subset";
 import { mongoose } from "@typegoose/typegoose";
 import { v4 as uuid } from "uuid";
 import { connect, clearDatabase, closeDatabase, setupMocks } from "../utils";
+// Mocks must be set before the following imports.
 (async () => {
   await setupMocks();
 })();
@@ -22,11 +23,12 @@ before(async function () {
   this.timeout(120000); // 2 mins to download a local MongoDB installation.
   await connect();
 });
-
 /**
  * Clear all test data after every test.
  */
-afterEach(async () => await clearDatabase());
+afterEach(async () =>{ 
+  await clearDatabase(); 
+});
 
 /**
  * Remove and close the db and server.

--- a/yarn.lock
+++ b/yarn.lock
@@ -12551,10 +12551,10 @@ mongoose-algolia@^1.10.1:
     cli-color "^1.1.0"
     deep-keys "^0.4.0"
 
-mongoose-autopopulate@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.npmjs.org/mongoose-autopopulate/-/mongoose-autopopulate-0.12.3.tgz"
-  integrity sha512-yNmYsfi6OpS/GQ+48mkB0KQ199ExHmmPrt3wt3fyxPHPMtEBGts7yq3wBQR6VgKCPOQaKvCI1URbJCPOtrPeLw==
+mongoose-autopopulate@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/mongoose-autopopulate/-/mongoose-autopopulate-0.14.0.tgz#cfe69a877c10c7965b7f13f3d9dd410ec6f8f429"
+  integrity sha512-3EsOeFpEAwK2XQntI9CUf7dOq5HpI3lZFYzXukD0ep0Ctmdewgyt5VgS64Afuf/K6QggLt9RKsjexVphnhmeXg==
 
 mongoose-legacy-pluralize@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Demo: https://asciinema.org/a/hkHbWuIGCnBOIJN3TBGNCIVu5

* Creating a mentorship manually is rather cumbersome if you can't login to the parents/mentors account. This CLI sends a mentorship request on behalf of the parent. It validates the emails before sending the request and allows the user to select the specific child that you're requesting mentorship for. 

* Turns out that autopopulate was setup incorrectly by yours truly. No wonder sending requests failed sometimes. This fixes it. 